### PR TITLE
Show repo as using R code

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+*.eps linguist-vendored
+*.Rmd linguist-language=R


### PR DESCRIPTION
Currently shows up as postscript; 

Set up .gitattribute file to properly show up as a repo for R code so it's easier to browse for by users.